### PR TITLE
Support root base directory ($baseDir = "";)

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,7 +23,9 @@ if(substr($requestURI, 0, 1) == "/") {
   $requestURI = substr($requestURI, 1);
 }
 
-$requestURI = str_replace($baseDir."/", "", $requestURI);
+if($baseDir != "") { 
+  $requestURI = str_replace($baseDir."/", "", $requestURI); 
+}
 list($maptype, $zoom, $x, $y) = explode("/", $requestURI);
 
 if($maptype == "" || $zoom == "" || $x == "" || $y == "") {


### PR DESCRIPTION
I am using this script to serve a cache from a subdomain and index.php is at the root of the domain, as is the cache dir. This caused a str_replace error whereby all slashes were removed when trying to explode the uri.